### PR TITLE
Fix Baseline Limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dng-mdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dng-mdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Doors NG Model Development Kit",
   "repository": {
     "type": "git",

--- a/src/main/cli.mjs
+++ b/src/main/cli.mjs
@@ -195,8 +195,8 @@ y_yargs = y_yargs.command({
 			if(g_argv.sockets) a_args.push(...['--sockets', g_argv.sockets+'']);
 			if(g_argv.requests) a_args.push(...['--requests', g_argv.requests+'']);
 			if(g_argv.reset) a_args.push(...['--reset']);
-			if(g_argv.baselines) a_args.push(...['--baselines', g_argv.baselines+'']);
-			if(g_argv.authRetries) a_args.push(...['--auth-retries', g_argv.authRetries+'']);
+			if('baselines' in g_argv) a_args.push(...['--baselines', g_argv.baselines+'']);
+			if('authRetries' in g_argv) a_args.push(...['--auth-retries', g_argv.authRetries+'']);
 			if(g_argv.useFolders) a_args.push(...['--use-folders']);
 			if(g_argv.dryRun) a_args.push(...['--dry-run']);
 


### PR DESCRIPTION
When using `--malloc` CLI option, the baseline limit was not correctly carried over to child process.